### PR TITLE
Comentado linhas que geravam erro na criação dos certificados

### DIFF
--- a/mosquitto/tls/generate-CA.sh
+++ b/mosquitto/tls/generate-CA.sh
@@ -186,12 +186,12 @@ if [ $kind == 'server' ]; then
 		%%% ## nsCaRevocationUrl       = http://mqttitude.org/carev/
 		%%% ## nsRevocationUrl         = http://mqttitude.org/carev/
 		%%% certificatePolicies     = ia5org,@polsection
-		%%%
+		#%%%
 		%%% [polsection]
 		%%% policyIdentifier	    = 1.3.5.8
 		%%% CPS.1		    = "http://localhost"
 		%%% userNotice.1	    = @notice
-		%%%
+		#%%%
 		%%% [notice]
 		%%% explicitText            = "This CA is for a local MQTT broker installation only"
 		%%% organization            = "OwnTracks"


### PR DESCRIPTION
Ao executar o script generate-CA.sh, retornava o seguinte erro:
"error on line 13 of config file '/tmp/cacnf.4pBK2n1W'"
Foi resolvido comentando as linhas com %%%.
Estou usando Debian Jessie 8.8